### PR TITLE
chore: add .worktrees/ to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,6 @@ __pycache__/
 Thumbs.db
 .vscode/
 .idea/
+
+# Git worktrees
+.worktrees/


### PR DESCRIPTION
## Summary
- Added `.worktrees/` to `.gitignore` to support git worktrees workflow

## Test plan
- [x] Pre-commit hooks pass
- [x] Changes staged and committed in worktree
- [ ] Verify `.worktrees/` directory is ignored after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)