### PR TITLE
Fix content script re-injection SyntaxError

### DIFF
--- a/src/chrome-ext/collect.ts
+++ b/src/chrome-ext/collect.ts
@@ -6,682 +6,695 @@ import type {
   RosterEntryRecord,
 } from './shared/types';
 
-const RESULT_MESSAGE = 'refresh-result';
-const PROGRESS_MESSAGE = 'refresh-progress';
-const HOME_URL = 'https://www.mountaineers.org/';
-const HISTORY_SUFFIX = '/member-activity-history.json';
-const ROSTER_SEGMENT = 'roster-tab';
+// Wrap entire script in IIFE to prevent redeclaration errors on re-injection
+(() => {
+  const RESULT_MESSAGE = 'refresh-result';
+  const PROGRESS_MESSAGE = 'refresh-progress';
+  const HOME_URL = 'https://www.mountaineers.org/';
+  const HISTORY_SUFFIX = '/member-activity-history.json';
+  const ROSTER_SEGMENT = 'roster-tab';
 
-(async () => {
-  const existingActivityUids = new Set<string>(window.__mtgExistingActivityUids ?? []);
-  const fetchLimit =
-    typeof window.__mtgFetchLimit === 'number' && window.__mtgFetchLimit > 0
-      ? window.__mtgFetchLimit
-      : null;
+  (async () => {
+    const existingActivityUids = new Set<string>(window.__mtgExistingActivityUids ?? []);
+    const fetchLimit =
+      typeof window.__mtgFetchLimit === 'number' && window.__mtgFetchLimit > 0
+        ? window.__mtgFetchLimit
+        : null;
 
-  if (window.__mtgScrapeRunning) {
-    return;
-  }
-  window.__mtgScrapeRunning = true;
-
-  try {
-    console.info('Mountaineers Assistant: starting refresh workflow');
-    sendProgressUpdate({ stage: 'fetching-activities', total: 0, completed: 0 });
-
-    const { activities, currentUserUid } = await collectMemberActivities(
-      existingActivityUids,
-      fetchLimit
-    );
-
-    console.info('Mountaineers Assistant: loaded %d activities', activities.length);
-    const totalActivities = activities.length;
-    if (totalActivities === 0) {
-      sendProgressUpdate({ stage: 'no-new-activities', total: 0, completed: 0 });
-    } else {
-      sendProgressUpdate({ stage: 'activities-collected', total: totalActivities, completed: 0 });
+    if (window.__mtgScrapeRunning) {
+      return;
     }
+    window.__mtgScrapeRunning = true;
 
-    const exportData = await loadRosters(activities);
-    console.info(
-      'Mountaineers Assistant: collected %d people and %d roster entries',
-      exportData.people.length,
-      exportData.rosterEntries.length
-    );
+    try {
+      console.info('Mountaineers Assistant: starting refresh workflow');
+      sendProgressUpdate({ stage: 'fetching-activities', total: 0, completed: 0 });
 
-    sendProgressUpdate({ stage: 'finalizing', total: totalActivities, completed: totalActivities });
-
-    chrome.runtime.sendMessage({
-      type: RESULT_MESSAGE,
-      success: true,
-      data: {
-        ...exportData,
-        currentUserUid,
-      } satisfies CollectorSuccessPayload,
-    });
-  } catch (error: unknown) {
-    console.error('Mountaineers Assistant: refresh failed', error);
-    const errorMessage = error instanceof Error ? error.message : String(error);
-    sendProgressUpdate({
-      stage: 'error',
-      total: 0,
-      completed: 0,
-      error: errorMessage,
-    });
-    chrome.runtime.sendMessage({
-      type: RESULT_MESSAGE,
-      success: false,
-      error: errorMessage,
-    });
-  } finally {
-    window.__mtgScrapeRunning = false;
-    delete window.__mtgExistingActivityUids;
-    delete window.__mtgFetchLimit;
-  }
-})();
-
-async function collectMemberActivities(
-  existingActivityUids: Set<string>,
-  fetchLimit: number | null
-): Promise<{ activities: ActivityRecord[]; currentUserUid: string | null }> {
-  const { url: activitiesUrl, currentUserUid } = await discoverActivitiesUrl();
-  const historyUrl = deriveHistoryUrl(activitiesUrl);
-  const { csrfToken, refererUrl } = await collectCsrfToken(activitiesUrl);
-  const payload = await fetchHistoryPayload(historyUrl, refererUrl, csrfToken);
-
-  const activities = payload
-    .map(normalizeActivity)
-    .filter((activity): activity is ActivityRecord => {
-      if (!activity) {
-        return false;
-      }
-      if (!isSuccessful(activity)) {
-        return false;
-      }
-      return !existingActivityUids.has(activity.uid);
-    })
-    .sort((a, b) => {
-      const timeA = a.start_date ? new Date(a.start_date).getTime() : 0;
-      const timeB = b.start_date ? new Date(b.start_date).getTime() : 0;
-      return timeB - timeA;
-    });
-
-  const limitedActivities =
-    typeof fetchLimit === 'number' && fetchLimit > 0 ? activities.slice(0, fetchLimit) : activities;
-
-  return { activities: limitedActivities, currentUserUid };
-}
-
-async function discoverActivitiesUrl(): Promise<{ url: string; currentUserUid: string | null }> {
-  console.debug('Mountaineers Assistant: fetching homepage to locate activities link');
-  const response = await fetch(HOME_URL, { credentials: 'include' });
-  if (!response.ok) {
-    throw new Error(`Failed to load homepage (${response.status})`);
-  }
-
-  const html = await response.text();
-  const parser = new DOMParser();
-  const doc = parser.parseFromString(html, 'text/html');
-  const links = Array.from(doc.querySelectorAll('a'));
-  const match = links.find((link) => link.textContent?.trim().includes('My Activities'));
-  if (!match) {
-    throw new Error("Unable to locate 'My Activities' link on homepage.");
-  }
-  const href = match.getAttribute('href') ?? '';
-  const url = new URL(href, response.url).toString();
-  console.debug('Mountaineers Assistant: activities URL discovered -> %s', url);
-  const profileSlug = extractProfileSlug(doc);
-  if (profileSlug) {
-    console.debug('Mountaineers Assistant: detected current user slug -> %s', profileSlug);
-  }
-  return { url, currentUserUid: profileSlug };
-}
-
-function deriveHistoryUrl(activitiesUrl: string): string {
-  const trimmed = activitiesUrl.replace(/\/$/, '');
-  if (trimmed.endsWith('/member-activities')) {
-    return `${trimmed.slice(0, -'/member-activities'.length)}${HISTORY_SUFFIX}`;
-  }
-  throw new Error('Activities URL does not match expected pattern.');
-}
-
-async function collectCsrfToken(
-  activitiesUrl: string
-): Promise<{ csrfToken: string | null; refererUrl: string }> {
-  console.debug('Mountaineers Assistant: loading activities page to collect CSRF token');
-  const response = await fetch(activitiesUrl, { credentials: 'include' });
-  if (!response.ok) {
-    throw new Error(`Failed to load activities page (${response.status})`);
-  }
-  const html = await response.text();
-  const parser = new DOMParser();
-  const doc = parser.parseFromString(html, 'text/html');
-  const metaToken = doc.querySelector('meta[name="csrf-token"]')?.getAttribute('content') ?? null;
-  const dataToken = doc.querySelector('[data-csrf-token]')?.getAttribute('data-csrf-token') ?? null;
-  const scriptTokenMatch = html.match(/x-csrf-token\s*=\s*"([^"]+)"/i);
-  const csrfToken =
-    metaToken || dataToken || (scriptTokenMatch ? decodeHtml(scriptTokenMatch[1]) : null);
-  return { csrfToken, refererUrl: response.url };
-}
-
-async function fetchHistoryPayload(
-  historyUrl: string,
-  refererUrl: string,
-  csrfToken: string | null
-): Promise<unknown[]> {
-  const headers: Record<string, string> = {
-    Accept: 'application/json, text/javascript, */*; q=0.01',
-    'X-Requested-With': 'XMLHttpRequest',
-    Referer: refererUrl,
-  };
-  if (csrfToken) {
-    headers['X-CSRF-Token'] = csrfToken;
-  }
-  console.debug('Mountaineers Assistant: requesting history payload %s', historyUrl);
-  const response = await fetch(historyUrl, {
-    credentials: 'include',
-    headers,
-  });
-  if (!response.ok) {
-    throw new Error(`Failed to fetch activity history (${response.status})`);
-  }
-  const payload = await response.json();
-  if (Array.isArray(payload)) {
-    return payload;
-  }
-  for (const key of ['items', 'results', 'data']) {
-    if (Array.isArray((payload as Record<string, unknown>)[key])) {
-      return (payload as Record<string, unknown>)[key] as unknown[];
-    }
-  }
-  throw new Error('Unexpected JSON structure from activity history endpoint.');
-}
-
-function normalizeActivity(record: unknown): ActivityRecord | null {
-  if (!isRecord(record)) {
-    return null;
-  }
-  const uidRaw = stringOrNull(record.uid);
-  const uid = uidRaw ? uidRaw.trim() : null;
-  const hrefRaw = stringOrNull(record.href);
-  const href = ensureAbsoluteUrl(hrefRaw ? hrefRaw.trim() : null);
-  if (!uid || !href) {
-    return null;
-  }
-
-  return {
-    uid,
-    href,
-    title: stringOrNull(record.title),
-    category: stringOrNull(record.category),
-    start_date: parseDate((record as Record<string, unknown>).start),
-    trip_results: stringOrNull(record.trip_results),
-    result: stringOrNull(record.result),
-    rawResult: record.result,
-    activity_type: stringOrNull(record.activity_type),
-  };
-}
-
-function isSuccessful(activity: ActivityRecord): boolean {
-  const result = (activity.result ?? activity.rawResult ?? '').toString().toLowerCase();
-  return result === 'successful';
-}
-
-async function loadRosters(
-  activities: ActivityRecord[]
-): Promise<Omit<CollectorSuccessPayload, 'currentUserUid'>> {
-  const peopleByUid = new Map<string, PersonRecord>();
-  const rosterEntries: RosterEntryRecord[] = [];
-  const enrichedActivities: ActivityRecord[] = [];
-  const total = activities.length;
-  let processed = 0;
-
-  if (total > 0) {
-    sendProgressUpdate({ stage: 'processing', total, completed: 0 });
-  }
-
-  for (const activity of activities) {
-    let resolvedType = activity.activity_type ?? null;
-    const activityTitle = activity.title ?? null;
-
-    const detailsPromise = loadActivityDetails(activity);
-    const rosterPromise = loadActivityRoster(activity);
-
-    sendProgressUpdate({
-      stage: 'loading-details',
-      total,
-      completed: processed,
-      activityUid: activity.uid,
-      activityTitle,
-    });
-
-    const detailsResult = await settlePromise(detailsPromise);
-
-    if (detailsResult.status === 'fulfilled') {
-      if (detailsResult.value.activityType) {
-        resolvedType = detailsResult.value.activityType;
-      }
-    } else {
-      console.warn(
-        `Mountaineers Assistant: failed to load activity details for ${activity.uid}`,
-        detailsResult.reason
+      const { activities, currentUserUid } = await collectMemberActivities(
+        existingActivityUids,
+        fetchLimit
       );
-    }
 
-    sendProgressUpdate({
-      stage: 'loading-roster',
-      total,
-      completed: processed,
-      activityUid: activity.uid,
-      activityTitle,
-    });
-
-    const rosterResult = await settlePromise(rosterPromise);
-
-    if (rosterResult.status === 'fulfilled') {
-      const { people, entries } = rosterResult.value;
-      for (const person of people) {
-        const existing = peopleByUid.get(person.uid);
-        if (!existing) {
-          peopleByUid.set(person.uid, person);
-          continue;
-        }
-        const mergedPerson: PersonRecord = { ...existing };
-        let changed = false;
-        if (!existing.href && person.href) {
-          mergedPerson.href = person.href;
-          changed = true;
-        }
-        if (!existing.avatar && person.avatar) {
-          mergedPerson.avatar = person.avatar;
-          changed = true;
-        }
-        if (!existing.name && person.name) {
-          mergedPerson.name = person.name;
-          changed = true;
-        }
-        if (changed) {
-          peopleByUid.set(person.uid, mergedPerson);
-        }
+      console.info('Mountaineers Assistant: loaded %d activities', activities.length);
+      const totalActivities = activities.length;
+      if (totalActivities === 0) {
+        sendProgressUpdate({ stage: 'no-new-activities', total: 0, completed: 0 });
+      } else {
+        sendProgressUpdate({ stage: 'activities-collected', total: totalActivities, completed: 0 });
       }
-      rosterEntries.push(...entries);
-    } else {
-      console.warn(`Failed to collect roster for ${activity.uid}`, rosterResult.reason);
+
+      const exportData = await loadRosters(activities);
+      console.info(
+        'Mountaineers Assistant: collected %d people and %d roster entries',
+        exportData.people.length,
+        exportData.rosterEntries.length
+      );
+
+      sendProgressUpdate({
+        stage: 'finalizing',
+        total: totalActivities,
+        completed: totalActivities,
+      });
+
+      chrome.runtime.sendMessage({
+        type: RESULT_MESSAGE,
+        success: true,
+        data: {
+          ...exportData,
+          currentUserUid,
+        } satisfies CollectorSuccessPayload,
+      });
+    } catch (error: unknown) {
+      console.error('Mountaineers Assistant: refresh failed', error);
+      const errorMessage = error instanceof Error ? error.message : String(error);
+      sendProgressUpdate({
+        stage: 'error',
+        total: 0,
+        completed: 0,
+        error: errorMessage,
+      });
+      chrome.runtime.sendMessage({
+        type: RESULT_MESSAGE,
+        success: false,
+        error: errorMessage,
+      });
+    } finally {
+      window.__mtgScrapeRunning = false;
+      delete window.__mtgExistingActivityUids;
+      delete window.__mtgFetchLimit;
+    }
+  })();
+
+  async function collectMemberActivities(
+    existingActivityUids: Set<string>,
+    fetchLimit: number | null
+  ): Promise<{ activities: ActivityRecord[]; currentUserUid: string | null }> {
+    const { url: activitiesUrl, currentUserUid } = await discoverActivitiesUrl();
+    const historyUrl = deriveHistoryUrl(activitiesUrl);
+    const { csrfToken, refererUrl } = await collectCsrfToken(activitiesUrl);
+    const payload = await fetchHistoryPayload(historyUrl, refererUrl, csrfToken);
+
+    const activities = payload
+      .map(normalizeActivity)
+      .filter((activity): activity is ActivityRecord => {
+        if (!activity) {
+          return false;
+        }
+        if (!isSuccessful(activity)) {
+          return false;
+        }
+        return !existingActivityUids.has(activity.uid);
+      })
+      .sort((a, b) => {
+        const timeA = a.start_date ? new Date(a.start_date).getTime() : 0;
+        const timeB = b.start_date ? new Date(b.start_date).getTime() : 0;
+        return timeB - timeA;
+      });
+
+    const limitedActivities =
+      typeof fetchLimit === 'number' && fetchLimit > 0
+        ? activities.slice(0, fetchLimit)
+        : activities;
+
+    return { activities: limitedActivities, currentUserUid };
+  }
+
+  async function discoverActivitiesUrl(): Promise<{ url: string; currentUserUid: string | null }> {
+    console.debug('Mountaineers Assistant: fetching homepage to locate activities link');
+    const response = await fetch(HOME_URL, { credentials: 'include' });
+    if (!response.ok) {
+      throw new Error(`Failed to load homepage (${response.status})`);
     }
 
-    const enrichedActivity: ActivityRecord = { ...activity, activity_type: resolvedType };
-    enrichedActivities.push(enrichedActivity);
-    processed += 1;
-    const rosterDelta =
-      rosterResult.status === 'fulfilled'
-        ? {
-            people: rosterResult.value.people,
-            rosterEntries: rosterResult.value.entries,
-          }
-        : {
-            people: [],
-            rosterEntries: [],
-          };
-    sendProgressUpdate({
-      stage: 'processing',
-      total,
-      completed: processed,
-      activityUid: activity.uid,
-      activityTitle,
-      delta: {
-        activities: [enrichedActivity],
-        people: rosterDelta.people,
-        rosterEntries: rosterDelta.rosterEntries,
-      },
-    });
+    const html = await response.text();
+    const parser = new DOMParser();
+    const doc = parser.parseFromString(html, 'text/html');
+    const links = Array.from(doc.querySelectorAll('a'));
+    const match = links.find((link) => link.textContent?.trim().includes('My Activities'));
+    if (!match) {
+      throw new Error("Unable to locate 'My Activities' link on homepage.");
+    }
+    const href = match.getAttribute('href') ?? '';
+    const url = new URL(href, response.url).toString();
+    console.debug('Mountaineers Assistant: activities URL discovered -> %s', url);
+    const profileSlug = extractProfileSlug(doc);
+    if (profileSlug) {
+      console.debug('Mountaineers Assistant: detected current user slug -> %s', profileSlug);
+    }
+    return { url, currentUserUid: profileSlug };
   }
 
-  return {
-    activities: enrichedActivities,
-    people: Array.from(peopleByUid.values()),
-    rosterEntries,
-  };
-}
-
-function settlePromise<T>(promise: Promise<T>): Promise<PromiseSettledResult<T>> {
-  return promise
-    .then<PromiseSettledResult<T>>((value) => ({ status: 'fulfilled', value }))
-    .catch<PromiseSettledResult<T>>((reason) => ({ status: 'rejected', reason }));
-}
-
-function sendProgressUpdate(update: {
-  stage: string;
-  total?: number;
-  completed?: number;
-  activityUid?: string;
-  activityTitle?: string | null;
-  error?: string;
-  delta?: CollectorDelta;
-}): void {
-  if (!update || typeof chrome?.runtime?.sendMessage !== 'function') {
-    return;
-  }
-  const payload: Record<string, unknown> = {
-    stage: typeof update.stage === 'string' ? update.stage : 'unknown',
-    timestamp: Date.now(),
-  };
-  if (Number.isFinite(update.total)) {
-    payload.total = Math.max(0, Math.floor(update.total as number));
-  }
-  if (Number.isFinite(update.completed)) {
-    payload.completed = Math.max(0, Math.floor(update.completed as number));
-  }
-  if (typeof update.activityUid === 'string') {
-    payload.activityUid = update.activityUid;
-  }
-  if (typeof update.activityTitle === 'string') {
-    payload.activityTitle = update.activityTitle;
-  }
-  if (update.error) {
-    payload.error = update.error;
-  }
-  const delta = sanitizeDelta(update.delta);
-  if (delta) {
-    payload.delta = delta;
+  function deriveHistoryUrl(activitiesUrl: string): string {
+    const trimmed = activitiesUrl.replace(/\/$/, '');
+    if (trimmed.endsWith('/member-activities')) {
+      return `${trimmed.slice(0, -'/member-activities'.length)}${HISTORY_SUFFIX}`;
+    }
+    throw new Error('Activities URL does not match expected pattern.');
   }
 
-  try {
-    chrome.runtime.sendMessage({
-      type: PROGRESS_MESSAGE,
-      origin: 'collector',
-      ...payload,
-    });
-  } catch (error) {
-    console.warn('Mountaineers Assistant: failed to send progress update', error);
-  }
-}
-
-function sanitizeDelta(delta: CollectorDelta | null | undefined): CollectorDelta | null {
-  if (!delta || typeof delta !== 'object') {
-    return null;
-  }
-  const activities = Array.isArray(delta.activities)
-    ? delta.activities.map((activity) => ({ ...activity }))
-    : [];
-  const people = Array.isArray(delta.people) ? delta.people.map((person) => ({ ...person })) : [];
-  const rosterEntries = Array.isArray(delta.rosterEntries)
-    ? delta.rosterEntries.map((entry) => ({ ...entry }))
-    : [];
-  if (!activities.length && !people.length && !rosterEntries.length) {
-    return null;
-  }
-  return {
-    activities,
-    people,
-    rosterEntries,
-  };
-}
-
-async function loadActivityDetails(
-  activity: ActivityRecord
-): Promise<{ activityType: string | null }> {
-  if (!activity?.href) {
-    return { activityType: null };
-  }
-  try {
-    const response = await fetch(activity.href, { credentials: 'include' });
+  async function collectCsrfToken(
+    activitiesUrl: string
+  ): Promise<{ csrfToken: string | null; refererUrl: string }> {
+    console.debug('Mountaineers Assistant: loading activities page to collect CSRF token');
+    const response = await fetch(activitiesUrl, { credentials: 'include' });
     if (!response.ok) {
+      throw new Error(`Failed to load activities page (${response.status})`);
+    }
+    const html = await response.text();
+    const parser = new DOMParser();
+    const doc = parser.parseFromString(html, 'text/html');
+    const metaToken = doc.querySelector('meta[name="csrf-token"]')?.getAttribute('content') ?? null;
+    const dataToken =
+      doc.querySelector('[data-csrf-token]')?.getAttribute('data-csrf-token') ?? null;
+    const scriptTokenMatch = html.match(/x-csrf-token\s*=\s*"([^"]+)"/i);
+    const csrfToken =
+      metaToken || dataToken || (scriptTokenMatch ? decodeHtml(scriptTokenMatch[1]) : null);
+    return { csrfToken, refererUrl: response.url };
+  }
+
+  async function fetchHistoryPayload(
+    historyUrl: string,
+    refererUrl: string,
+    csrfToken: string | null
+  ): Promise<unknown[]> {
+    const headers: Record<string, string> = {
+      Accept: 'application/json, text/javascript, */*; q=0.01',
+      'X-Requested-With': 'XMLHttpRequest',
+      Referer: refererUrl,
+    };
+    if (csrfToken) {
+      headers['X-CSRF-Token'] = csrfToken;
+    }
+    console.debug('Mountaineers Assistant: requesting history payload %s', historyUrl);
+    const response = await fetch(historyUrl, {
+      credentials: 'include',
+      headers,
+    });
+    if (!response.ok) {
+      throw new Error(`Failed to fetch activity history (${response.status})`);
+    }
+    const payload = await response.json();
+    if (Array.isArray(payload)) {
+      return payload;
+    }
+    for (const key of ['items', 'results', 'data']) {
+      if (Array.isArray((payload as Record<string, unknown>)[key])) {
+        return (payload as Record<string, unknown>)[key] as unknown[];
+      }
+    }
+    throw new Error('Unexpected JSON structure from activity history endpoint.');
+  }
+
+  function normalizeActivity(record: unknown): ActivityRecord | null {
+    if (!isRecord(record)) {
+      return null;
+    }
+    const uidRaw = stringOrNull(record.uid);
+    const uid = uidRaw ? uidRaw.trim() : null;
+    const hrefRaw = stringOrNull(record.href);
+    const href = ensureAbsoluteUrl(hrefRaw ? hrefRaw.trim() : null);
+    if (!uid || !href) {
+      return null;
+    }
+
+    return {
+      uid,
+      href,
+      title: stringOrNull(record.title),
+      category: stringOrNull(record.category),
+      start_date: parseDate((record as Record<string, unknown>).start),
+      trip_results: stringOrNull(record.trip_results),
+      result: stringOrNull(record.result),
+      rawResult: record.result,
+      activity_type: stringOrNull(record.activity_type),
+    };
+  }
+
+  function isSuccessful(activity: ActivityRecord): boolean {
+    const result = (activity.result ?? activity.rawResult ?? '').toString().toLowerCase();
+    return result === 'successful';
+  }
+
+  async function loadRosters(
+    activities: ActivityRecord[]
+  ): Promise<Omit<CollectorSuccessPayload, 'currentUserUid'>> {
+    const peopleByUid = new Map<string, PersonRecord>();
+    const rosterEntries: RosterEntryRecord[] = [];
+    const enrichedActivities: ActivityRecord[] = [];
+    const total = activities.length;
+    let processed = 0;
+
+    if (total > 0) {
+      sendProgressUpdate({ stage: 'processing', total, completed: 0 });
+    }
+
+    for (const activity of activities) {
+      let resolvedType = activity.activity_type ?? null;
+      const activityTitle = activity.title ?? null;
+
+      const detailsPromise = loadActivityDetails(activity);
+      const rosterPromise = loadActivityRoster(activity);
+
+      sendProgressUpdate({
+        stage: 'loading-details',
+        total,
+        completed: processed,
+        activityUid: activity.uid,
+        activityTitle,
+      });
+
+      const detailsResult = await settlePromise(detailsPromise);
+
+      if (detailsResult.status === 'fulfilled') {
+        if (detailsResult.value.activityType) {
+          resolvedType = detailsResult.value.activityType;
+        }
+      } else {
+        console.warn(
+          `Mountaineers Assistant: failed to load activity details for ${activity.uid}`,
+          detailsResult.reason
+        );
+      }
+
+      sendProgressUpdate({
+        stage: 'loading-roster',
+        total,
+        completed: processed,
+        activityUid: activity.uid,
+        activityTitle,
+      });
+
+      const rosterResult = await settlePromise(rosterPromise);
+
+      if (rosterResult.status === 'fulfilled') {
+        const { people, entries } = rosterResult.value;
+        for (const person of people) {
+          const existing = peopleByUid.get(person.uid);
+          if (!existing) {
+            peopleByUid.set(person.uid, person);
+            continue;
+          }
+          const mergedPerson: PersonRecord = { ...existing };
+          let changed = false;
+          if (!existing.href && person.href) {
+            mergedPerson.href = person.href;
+            changed = true;
+          }
+          if (!existing.avatar && person.avatar) {
+            mergedPerson.avatar = person.avatar;
+            changed = true;
+          }
+          if (!existing.name && person.name) {
+            mergedPerson.name = person.name;
+            changed = true;
+          }
+          if (changed) {
+            peopleByUid.set(person.uid, mergedPerson);
+          }
+        }
+        rosterEntries.push(...entries);
+      } else {
+        console.warn(`Failed to collect roster for ${activity.uid}`, rosterResult.reason);
+      }
+
+      const enrichedActivity: ActivityRecord = { ...activity, activity_type: resolvedType };
+      enrichedActivities.push(enrichedActivity);
+      processed += 1;
+      const rosterDelta =
+        rosterResult.status === 'fulfilled'
+          ? {
+              people: rosterResult.value.people,
+              rosterEntries: rosterResult.value.entries,
+            }
+          : {
+              people: [],
+              rosterEntries: [],
+            };
+      sendProgressUpdate({
+        stage: 'processing',
+        total,
+        completed: processed,
+        activityUid: activity.uid,
+        activityTitle,
+        delta: {
+          activities: [enrichedActivity],
+          people: rosterDelta.people,
+          rosterEntries: rosterDelta.rosterEntries,
+        },
+      });
+    }
+
+    return {
+      activities: enrichedActivities,
+      people: Array.from(peopleByUid.values()),
+      rosterEntries,
+    };
+  }
+
+  function settlePromise<T>(promise: Promise<T>): Promise<PromiseSettledResult<T>> {
+    return promise
+      .then<PromiseSettledResult<T>>((value) => ({ status: 'fulfilled', value }))
+      .catch<PromiseSettledResult<T>>((reason) => ({ status: 'rejected', reason }));
+  }
+
+  function sendProgressUpdate(update: {
+    stage: string;
+    total?: number;
+    completed?: number;
+    activityUid?: string;
+    activityTitle?: string | null;
+    error?: string;
+    delta?: CollectorDelta;
+  }): void {
+    if (!update || typeof chrome?.runtime?.sendMessage !== 'function') {
+      return;
+    }
+    const payload: Record<string, unknown> = {
+      stage: typeof update.stage === 'string' ? update.stage : 'unknown',
+      timestamp: Date.now(),
+    };
+    if (Number.isFinite(update.total)) {
+      payload.total = Math.max(0, Math.floor(update.total as number));
+    }
+    if (Number.isFinite(update.completed)) {
+      payload.completed = Math.max(0, Math.floor(update.completed as number));
+    }
+    if (typeof update.activityUid === 'string') {
+      payload.activityUid = update.activityUid;
+    }
+    if (typeof update.activityTitle === 'string') {
+      payload.activityTitle = update.activityTitle;
+    }
+    if (update.error) {
+      payload.error = update.error;
+    }
+    const delta = sanitizeDelta(update.delta);
+    if (delta) {
+      payload.delta = delta;
+    }
+
+    try {
+      chrome.runtime.sendMessage({
+        type: PROGRESS_MESSAGE,
+        origin: 'collector',
+        ...payload,
+      });
+    } catch (error) {
+      console.warn('Mountaineers Assistant: failed to send progress update', error);
+    }
+  }
+
+  function sanitizeDelta(delta: CollectorDelta | null | undefined): CollectorDelta | null {
+    if (!delta || typeof delta !== 'object') {
+      return null;
+    }
+    const activities = Array.isArray(delta.activities)
+      ? delta.activities.map((activity) => ({ ...activity }))
+      : [];
+    const people = Array.isArray(delta.people) ? delta.people.map((person) => ({ ...person })) : [];
+    const rosterEntries = Array.isArray(delta.rosterEntries)
+      ? delta.rosterEntries.map((entry) => ({ ...entry }))
+      : [];
+    if (!activities.length && !people.length && !rosterEntries.length) {
+      return null;
+    }
+    return {
+      activities,
+      people,
+      rosterEntries,
+    };
+  }
+
+  async function loadActivityDetails(
+    activity: ActivityRecord
+  ): Promise<{ activityType: string | null }> {
+    if (!activity?.href) {
+      return { activityType: null };
+    }
+    try {
+      const response = await fetch(activity.href, { credentials: 'include' });
+      if (!response.ok) {
+        console.warn(
+          `Mountaineers Assistant: activity page unavailable (${response.status}) for ${activity.uid}`
+        );
+        return { activityType: null };
+      }
+      const html = await response.text();
+      return { activityType: extractActivityType(html) };
+    } catch (error) {
       console.warn(
-        `Mountaineers Assistant: activity page unavailable (${response.status}) for ${activity.uid}`
+        `Mountaineers Assistant: failed to load activity page for ${activity.uid}`,
+        error
       );
       return { activityType: null };
     }
+  }
+
+  function extractActivityType(html: string): string | null {
+    const parser = new DOMParser();
+    const doc = parser.parseFromString(html, 'text/html');
+    const detailItems = Array.from(doc.querySelectorAll('.program-core .details li'));
+    for (const item of detailItems) {
+      const label = item.querySelector('label');
+      const labelText = normalizeWhitespace(label?.textContent ?? '');
+      if (labelText && labelText.replace(/:$/, '').toLowerCase() === 'activity type') {
+        const clone = item.cloneNode(true) as HTMLElement;
+        const cloneLabel = clone.querySelector('label');
+        if (cloneLabel) {
+          cloneLabel.remove();
+        }
+        const value = normalizeWhitespace(clone.textContent ?? '');
+        if (value) {
+          return value;
+        }
+      }
+    }
+    return null;
+  }
+
+  async function loadActivityRoster(
+    activity: ActivityRecord
+  ): Promise<{ people: PersonRecord[]; entries: RosterEntryRecord[] }> {
+    if (!activity.href) {
+      return { people: [], entries: [] };
+    }
+    const rosterUrl = deriveRosterUrl(activity.href);
+    const response = await fetch(rosterUrl, {
+      credentials: 'include',
+      headers: {
+        Accept: 'text/html, */*; q=0.01',
+        'X-Requested-With': 'XMLHttpRequest',
+        Referer: activity.href,
+      },
+    });
+    if (!response.ok) {
+      throw new Error(`Roster fetch failed (${response.status})`);
+    }
+    const contentType = response.headers.get('Content-Type') ?? '';
+    if (contentType.includes('application/json')) {
+      const payload = await response.json();
+      if (payload?.error_type) {
+        throw new Error(`Roster request failed: ${payload.error_type}`);
+      }
+      return { people: [], entries: [] };
+    }
     const html = await response.text();
-    return { activityType: extractActivityType(html) };
-  } catch (error) {
-    console.warn(`Mountaineers Assistant: failed to load activity page for ${activity.uid}`, error);
-    return { activityType: null };
+    return parseRosterHtml(html, activity.uid);
   }
-}
 
-function extractActivityType(html: string): string | null {
-  const parser = new DOMParser();
-  const doc = parser.parseFromString(html, 'text/html');
-  const detailItems = Array.from(doc.querySelectorAll('.program-core .details li'));
-  for (const item of detailItems) {
-    const label = item.querySelector('label');
-    const labelText = normalizeWhitespace(label?.textContent ?? '');
-    if (labelText && labelText.replace(/:$/, '').toLowerCase() === 'activity type') {
-      const clone = item.cloneNode(true) as HTMLElement;
-      const cloneLabel = clone.querySelector('label');
-      if (cloneLabel) {
-        cloneLabel.remove();
+  function deriveRosterUrl(activityHref: string): string {
+    const url = new URL(activityHref);
+    const path = url.pathname.replace(/\/$/, '');
+    url.pathname = `${path}/${ROSTER_SEGMENT}`;
+    url.search = '';
+    url.hash = '';
+    return url.toString();
+  }
+
+  function parseRosterHtml(
+    html: string,
+    activityUid: string
+  ): {
+    people: PersonRecord[];
+    entries: RosterEntryRecord[];
+  } {
+    const parser = new DOMParser();
+    const doc = parser.parseFromString(html, 'text/html');
+    const contacts = Array.from(doc.querySelectorAll('.roster-contact'));
+    const people: PersonRecord[] = [];
+    const entries: RosterEntryRecord[] = [];
+
+    for (const contact of contacts) {
+      const parsed = parseRosterContact(contact as HTMLElement, activityUid);
+      if (!parsed) {
+        continue;
       }
-      const value = normalizeWhitespace(clone.textContent ?? '');
-      if (value) {
-        return value;
+      people.push(parsed.person);
+      entries.push(parsed.entry);
+    }
+
+    return { people, entries };
+  }
+
+  function parseRosterContact(
+    element: HTMLElement,
+    activityUid: string
+  ): { person: PersonRecord; entry: RosterEntryRecord } | null {
+    const name = extractText(element, ['.roster-name', "a[href*='/members/']", 'div']);
+    if (!name) {
+      return null;
+    }
+
+    const anchor = element.querySelector("a[href*='/members/']");
+    const anchorHref = anchor?.getAttribute('href') ?? null;
+    const href = anchorHref ? new URL(anchorHref, HOME_URL).toString() : null;
+    const img = element.querySelector("img[src*='/members/']");
+    const imageHref = img?.getAttribute('src') ?? null;
+
+    const rawSlugCandidate = anchorHref ?? imageHref;
+    const slug = extractSlug(rawSlugCandidate) ?? slugify(name);
+    if (!slug) {
+      return null;
+    }
+
+    const roleText = extractText(element, ['.roster-position']);
+    const role = normalizeRole(roleText);
+    const avatar = normalizeAvatarUrl(imageHref);
+
+    const person: PersonRecord = {
+      uid: slug,
+      href: href ?? buildMemberHref(slug),
+      name,
+      avatar,
+    };
+
+    const entry: RosterEntryRecord = {
+      activity_uid: activityUid,
+      person_uid: slug,
+      role,
+    };
+
+    return { person, entry };
+  }
+
+  function extractText(element: HTMLElement, selectors: string[]): string | null {
+    for (const selector of selectors) {
+      const node = element.querySelector(selector);
+      const text = node?.textContent?.trim();
+      if (text) {
+        return text;
       }
     }
+    const textContent = element.textContent?.trim();
+    return textContent || null;
   }
-  return null;
-}
 
-async function loadActivityRoster(
-  activity: ActivityRecord
-): Promise<{ people: PersonRecord[]; entries: RosterEntryRecord[] }> {
-  if (!activity.href) {
-    return { people: [], entries: [] };
-  }
-  const rosterUrl = deriveRosterUrl(activity.href);
-  const response = await fetch(rosterUrl, {
-    credentials: 'include',
-    headers: {
-      Accept: 'text/html, */*; q=0.01',
-      'X-Requested-With': 'XMLHttpRequest',
-      Referer: activity.href,
-    },
-  });
-  if (!response.ok) {
-    throw new Error(`Roster fetch failed (${response.status})`);
-  }
-  const contentType = response.headers.get('Content-Type') ?? '';
-  if (contentType.includes('application/json')) {
-    const payload = await response.json();
-    if (payload?.error_type) {
-      throw new Error(`Roster request failed: ${payload.error_type}`);
+  function extractSlug(value: string | null): string | null {
+    if (!value) {
+      return null;
     }
-    return { people: [], entries: [] };
+    const match = value.match(/\/members\/([^/]+)/);
+    return match ? match[1] : null;
   }
-  const html = await response.text();
-  return parseRosterHtml(html, activity.uid);
-}
 
-function deriveRosterUrl(activityHref: string): string {
-  const url = new URL(activityHref);
-  const path = url.pathname.replace(/\/$/, '');
-  url.pathname = `${path}/${ROSTER_SEGMENT}`;
-  url.search = '';
-  url.hash = '';
-  return url.toString();
-}
+  function buildMemberHref(slug: string): string {
+    return new URL(`/members/${slug}`, HOME_URL).toString();
+  }
 
-function parseRosterHtml(
-  html: string,
-  activityUid: string
-): {
-  people: PersonRecord[];
-  entries: RosterEntryRecord[];
-} {
-  const parser = new DOMParser();
-  const doc = parser.parseFromString(html, 'text/html');
-  const contacts = Array.from(doc.querySelectorAll('.roster-contact'));
-  const people: PersonRecord[] = [];
-  const entries: RosterEntryRecord[] = [];
-
-  for (const contact of contacts) {
-    const parsed = parseRosterContact(contact as HTMLElement, activityUid);
-    if (!parsed) {
-      continue;
+  function normalizeRole(roleText: string | null): string {
+    const defaultRole = 'Participant';
+    const knownRoles = ['Primary Leader', 'Assistant Leader', 'Instructor', 'Participant'];
+    if (!roleText) {
+      return defaultRole;
     }
-    people.push(parsed.person);
-    entries.push(parsed.entry);
-  }
-
-  return { people, entries };
-}
-
-function parseRosterContact(
-  element: HTMLElement,
-  activityUid: string
-): { person: PersonRecord; entry: RosterEntryRecord } | null {
-  const name = extractText(element, ['.roster-name', "a[href*='/members/']", 'div']);
-  if (!name) {
-    return null;
-  }
-
-  const anchor = element.querySelector("a[href*='/members/']");
-  const anchorHref = anchor?.getAttribute('href') ?? null;
-  const href = anchorHref ? new URL(anchorHref, HOME_URL).toString() : null;
-  const img = element.querySelector("img[src*='/members/']");
-  const imageHref = img?.getAttribute('src') ?? null;
-
-  const rawSlugCandidate = anchorHref ?? imageHref;
-  const slug = extractSlug(rawSlugCandidate) ?? slugify(name);
-  if (!slug) {
-    return null;
-  }
-
-  const roleText = extractText(element, ['.roster-position']);
-  const role = normalizeRole(roleText);
-  const avatar = normalizeAvatarUrl(imageHref);
-
-  const person: PersonRecord = {
-    uid: slug,
-    href: href ?? buildMemberHref(slug),
-    name,
-    avatar,
-  };
-
-  const entry: RosterEntryRecord = {
-    activity_uid: activityUid,
-    person_uid: slug,
-    role,
-  };
-
-  return { person, entry };
-}
-
-function extractText(element: HTMLElement, selectors: string[]): string | null {
-  for (const selector of selectors) {
-    const node = element.querySelector(selector);
-    const text = node?.textContent?.trim();
-    if (text) {
-      return text;
+    const cleaned = roleText.trim().toLowerCase();
+    const match = knownRoles.find((role) => role.toLowerCase() === cleaned);
+    if (match) {
+      return match;
     }
-  }
-  const textContent = element.textContent?.trim();
-  return textContent || null;
-}
-
-function extractSlug(value: string | null): string | null {
-  if (!value) {
-    return null;
-  }
-  const match = value.match(/\/members\/([^/]+)/);
-  return match ? match[1] : null;
-}
-
-function buildMemberHref(slug: string): string {
-  return new URL(`/members/${slug}`, HOME_URL).toString();
-}
-
-function normalizeRole(roleText: string | null): string {
-  const defaultRole = 'Participant';
-  const knownRoles = ['Primary Leader', 'Assistant Leader', 'Instructor', 'Participant'];
-  if (!roleText) {
+    if (cleaned.includes('participant')) {
+      return defaultRole;
+    }
     return defaultRole;
   }
-  const cleaned = roleText.trim().toLowerCase();
-  const match = knownRoles.find((role) => role.toLowerCase() === cleaned);
-  if (match) {
-    return match;
+
+  function normalizeAvatarUrl(value: string | null): string | null {
+    const url = ensureAbsoluteUrl(value);
+    if (!url) {
+      return null;
+    }
+    if (url.includes('/placeholder-contact-profile/')) {
+      return null;
+    }
+    return url;
   }
-  if (cleaned.includes('participant')) {
-    return defaultRole;
+
+  function normalizeWhitespace(value: string | null): string | null {
+    if (typeof value !== 'string') {
+      return null;
+    }
+    const cleaned = value.replace(/\s+/g, ' ').trim();
+    return cleaned || null;
   }
-  return defaultRole;
-}
 
-function normalizeAvatarUrl(value: string | null): string | null {
-  const url = ensureAbsoluteUrl(value);
-  if (!url) {
-    return null;
+  function slugify(value: string): string {
+    return value
+      .toLowerCase()
+      .normalize('NFKD')
+      .replace(/[^a-z0-9]+/g, '-')
+      .replace(/(^-|-$)/g, '');
   }
-  if (url.includes('/placeholder-contact-profile/')) {
-    return null;
+
+  function stringOrNull(value: unknown): string | null {
+    return typeof value === 'string' ? value : null;
   }
-  return url;
-}
 
-function normalizeWhitespace(value: string | null): string | null {
-  if (typeof value !== 'string') {
-    return null;
+  function parseDate(value: unknown): string | null {
+    if (!value) {
+      return null;
+    }
+    const parsed = new Date(value as string);
+    return Number.isNaN(parsed.getTime()) ? null : parsed.toISOString();
   }
-  const cleaned = value.replace(/\s+/g, ' ').trim();
-  return cleaned || null;
-}
 
-function slugify(value: string): string {
-  return value
-    .toLowerCase()
-    .normalize('NFKD')
-    .replace(/[^a-z0-9]+/g, '-')
-    .replace(/(^-|-$)/g, '');
-}
-
-function stringOrNull(value: unknown): string | null {
-  return typeof value === 'string' ? value : null;
-}
-
-function parseDate(value: unknown): string | null {
-  if (!value) {
-    return null;
+  function decodeHtml(value: string): string {
+    const textarea = document.createElement('textarea');
+    textarea.innerHTML = value;
+    return textarea.value;
   }
-  const parsed = new Date(value as string);
-  return Number.isNaN(parsed.getTime()) ? null : parsed.toISOString();
-}
 
-function decodeHtml(value: string): string {
-  const textarea = document.createElement('textarea');
-  textarea.innerHTML = value;
-  return textarea.value;
-}
-
-function extractProfileSlug(doc: Document): string | null {
-  const anchors = Array.from(doc.querySelectorAll("a[href*='/members/']"));
-  for (const anchor of anchors) {
-    const text = anchor.textContent?.trim().toLowerCase();
-    if (text && text.includes('my profile')) {
-      const href = anchor.getAttribute('href') ?? '';
-      const match = href.match(/\/members\/([^/]+)/);
-      if (match) {
-        return match[1];
+  function extractProfileSlug(doc: Document): string | null {
+    const anchors = Array.from(doc.querySelectorAll("a[href*='/members/']"));
+    for (const anchor of anchors) {
+      const text = anchor.textContent?.trim().toLowerCase();
+      if (text && text.includes('my profile')) {
+        const href = anchor.getAttribute('href') ?? '';
+        const match = href.match(/\/members\/([^/]+)/);
+        if (match) {
+          return match[1];
+        }
       }
     }
-  }
-  return null;
-}
-
-function ensureAbsoluteUrl(value: string | null): string | null {
-  if (!value) {
     return null;
   }
-  try {
-    return new URL(value, HOME_URL).toString();
-  } catch (error) {
-    console.warn(
-      'Mountaineers Assistant: unable to convert activity href to absolute URL',
-      value,
-      error
-    );
-    return value;
-  }
-}
 
-function isRecord(value: unknown): value is Record<string, unknown> {
-  return typeof value === 'object' && value !== null;
-}
+  function ensureAbsoluteUrl(value: string | null): string | null {
+    if (!value) {
+      return null;
+    }
+    try {
+      return new URL(value, HOME_URL).toString();
+    } catch (error) {
+      console.warn(
+        'Mountaineers Assistant: unable to convert activity href to absolute URL',
+        value,
+        error
+      );
+      return value;
+    }
+  }
+
+  function isRecord(value: unknown): value is Record<string, unknown> {
+    return typeof value === 'object' && value !== null;
+  }
+})();

--- a/tests/content-script-reinjection.spec.ts
+++ b/tests/content-script-reinjection.spec.ts
@@ -1,0 +1,80 @@
+import { test, expect, chromium } from '@playwright/test';
+import path from 'node:path';
+import fs from 'node:fs/promises';
+
+const distDir = path.resolve(process.cwd(), 'dist');
+const collectJsPath = path.join(distDir, 'collect.js');
+
+test.describe('Content script re-injection', () => {
+  test('should handle double injection without syntax errors', async () => {
+    // Read the collect.js file content
+    const scriptContent = await fs.readFile(collectJsPath, 'utf-8');
+
+    const context = await chromium.launchPersistentContext('', {
+      headless: true,
+      args: ['--headless=new'],
+    });
+
+    try {
+      const page = await context.newPage();
+
+      // Track all page errors
+      const pageErrors: Error[] = [];
+      page.on('pageerror', (error) => {
+        pageErrors.push(error);
+      });
+
+      // Navigate to a blank page
+      await page.goto('data:text/html,<html><head></head><body>Test page</body></html>');
+
+      // Inject the script by adding it as inline script (simulates chrome.scripting.executeScript)
+      // First injection
+      await page.evaluate((code) => {
+        window.__mtgExistingActivityUids = [];
+        window.__mtgFetchLimit = null;
+        const script = document.createElement('script');
+        script.textContent = code;
+        document.head.appendChild(script);
+      }, scriptContent);
+
+      // Wait for any async errors
+      await page.waitForTimeout(100);
+
+      // Second injection - this would trigger the redeclaration bug
+      await page.evaluate((code) => {
+        window.__mtgExistingActivityUids = [];
+        window.__mtgFetchLimit = null;
+        window.__mtgScrapeRunning = false;
+        const script = document.createElement('script');
+        script.textContent = code;
+        document.head.appendChild(script);
+      }, scriptContent);
+
+      // Wait for any async errors
+      await page.waitForTimeout(100);
+
+      // Check for syntax errors related to redeclaration
+      const hasSyntaxError = pageErrors.some((error) => {
+        const message = error.message.toLowerCase();
+        return (
+          message.includes('syntaxerror') ||
+          message.includes('has already been declared') ||
+          (message.includes('identifier') && message.includes('already'))
+        );
+      });
+
+      if (hasSyntaxError) {
+        console.log(
+          'Page errors detected:',
+          pageErrors.map((e) => e.message)
+        );
+      }
+
+      expect(hasSyntaxError).toBe(false);
+
+      await page.close();
+    } finally {
+      await context.close();
+    }
+  });
+});


### PR DESCRIPTION
## Summary

Fixes a bug where triggering multiple consecutive refreshes on the same tab caused a `SyntaxError: Identifier 'R' has already been declared` error in the Chrome DevTools console.

**Root Cause:**
- The content script (collect.js) had top-level `const` declarations in the global scope
- When `chrome.scripting.executeScript` re-injected the script for a second refresh, JavaScript tried to redeclare these constants
- This caused a parse-time SyntaxError before any runtime guards could prevent execution

**Solution:**
- Wrapped the entire script in an IIFE (Immediately Invoked Function Expression)
- Each injection now creates a new local function scope
- Constants can be safely redeclared in each new scope without conflicts

## Changes

- **src/chrome-ext/collect.ts**: Added IIFE wrapper around entire script
- **tests/content-script-reinjection.spec.ts**: New Playwright test that verifies double injection works without errors

## Test Plan

✅ Verified with TDD approach:
1. Created test that reproduces the bug
2. Confirmed test fails with original code (catches the bug)
3. Applied fix
4. Confirmed test passes with fixed code

**Manual Testing:**
1. Load the extension in Chrome
2. Navigate to a Mountaineers.org page
3. Trigger a refresh from the popup
4. Immediately trigger another refresh on the same tab
5. Check Chrome DevTools console - no SyntaxError should appear

**Automated Testing:**
```bash
npx playwright test content-script-reinjection --project=chromium-extension
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)