### PR TITLE
fix: preserve changelog history when bumping version

### DIFF
--- a/scripts/release-bump.js
+++ b/scripts/release-bump.js
@@ -3,7 +3,7 @@
 const { execSync } = require('child_process');
 const fs = require('fs');
 const path = require('path');
-const { generateChangelog } = require('./changelog-utils');
+const { generateChangelog, prependChangelogEntry } = require('./changelog-utils');
 
 const repoRoot = path.resolve(__dirname, '..');
 
@@ -170,10 +170,20 @@ function generateChangelogFile(version) {
   const changelogPath = path.join(repoRoot, 'CHANGELOG.md');
   const changelogDate = new Date().toISOString().split('T')[0]; // YYYY-MM-DD
 
-  console.log('Generating CHANGELOG.md...');
-  const changelogContent = generateChangelog(version, changelogDate);
+  console.log('Updating CHANGELOG.md...');
+
+  let changelogContent;
+  if (fs.existsSync(changelogPath)) {
+    // Read existing changelog and prepend new entry
+    const existingContent = fs.readFileSync(changelogPath, 'utf8');
+    changelogContent = prependChangelogEntry(existingContent, version, changelogDate);
+  } else {
+    // Create new changelog if it doesn't exist
+    changelogContent = generateChangelog(version, changelogDate);
+  }
+
   fs.writeFileSync(changelogPath, changelogContent, 'utf8');
-  console.log('✓ CHANGELOG.md generated\n');
+  console.log('✓ CHANGELOG.md updated\n');
 }
 
 function formatReleaseFiles() {


### PR DESCRIPTION
## Summary

- Update `release-bump` script to prepend new changelog entries instead of overwriting the file
- Preserve full changelog history across releases
- New entries are added at the top, existing entries remain intact

## Changes

- Added `parseExistingChangelog()` to separate header from release entries
- Added `prependChangelogEntry()` to prepend new releases while preserving history
- Modified `generateChangelogFile()` to check for existing changelog and prepend instead of overwrite

## Test plan

- [ ] Run `npm run release:bump 0.1.8` on a branch
- [ ] Verify CHANGELOG.md contains both new 0.1.8 entry and existing 0.1.7 entry
- [ ] Verify header remains intact
- [ ] Verify entries are in correct order (newest first)

🤖 Generated with [Claude Code](https://claude.com/claude-code)