### PR TITLE
docs: move release workflow from README to CONTRIBUTING

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -296,40 +296,50 @@ npm run typecheck   # Validate TypeScript
 
 ## Release Process
 
-This project uses a four-phase release workflow.
+We manage releases with [`just`](https://just.systems/man/en/) recipes and shell scripts.
 
-### Phase 1: Bump Version
-
-**From main branch**, create a release branch and bump version:
+**Prerequisites:** Install `just` locally along with `gh` (GitHub CLI), `npm`, `jq`, and `zip`.
 
 ```bash
-npm run release:bump 0.2.0
+# Install just (macOS)
+brew install just
+
+# Install GitHub CLI (if not already installed)
+brew install gh
+```
+
+### Phase 1: Prepare the Release Branch
+
+**From the main branch**, create a release branch and bump version:
+
+```bash
+just release-bump 0.2.4
+# or just release-bump patch|minor|major to auto-increment from the current version
 ```
 
 This script:
 
-1. Validates you're on `main` branch with a clean working tree
-2. Creates `release/v0.2.0` branch
-3. Bumps version in `package.json`, `package-lock.json`, and `manifest.json`
-4. Updates `CHANGELOG.md` by prepending new section (preserves existing history)
-5. Shows you the changes for review
+- Ensures you are on `main` with a clean working tree
+- Runs `npm run typecheck` from `main`
+- Creates or switches to `release/v0.2.4` (or the computed version)
+- Updates version metadata in `package.json`, `package-lock.json`, and `manifest.json`
+- Regenerates `CHANGELOG.md` with the latest commit titles
 
-**Note:** This script does NOT commit or push - you review changes first.
+**Note:** Changes are staged but not committed - review them first.
 
-### Phase 2: Submit Release PR
+### Phase 2: Commit and Open the Draft PR
 
 **From the release branch**, commit and create PR:
 
 ```bash
-npm run release:submit
+just release-submit
 ```
 
 This script:
 
-1. Validates you're on a `release/v*` branch
-2. Stages and commits release files: `package.json`, `package-lock.json`, `manifest.json`, `CHANGELOG.md`
-3. Pushes the release branch to origin
-4. Creates a pull request to `main` with changelog as description
+- Commits the staged release files
+- Pushes the release branch
+- Opens a draft PR populated with the changelog entry
 
 **Next:** Review the PR, ensure CI passes, then merge on GitHub.
 
@@ -341,7 +351,7 @@ The [Release workflow](.github/workflows/release.yml) automatically:
 
 1. Detects the merged release PR (`release/v*` branch)
 2. Extracts version from branch name
-3. Creates and pushes git tag `v0.2.0`
+3. Creates and pushes git tag
 4. Builds production bundle
 5. Packages extension as ZIP
 6. Creates GitHub release with ZIP attachment and changelog notes
@@ -351,10 +361,10 @@ The [Release workflow](.github/workflows/release.yml) automatically:
 ```bash
 git checkout main
 git pull
-npm run release:publish 0.2.0
+just release-publish 0.2.4
 ```
 
-This runs the same steps manually.
+This verifies `main` matches the merged release, builds the extension, creates `mountaineers-assistant-0.2.4.zip`, tags the release, and creates the GitHub release with the ZIP attached.
 
 **Next:** Phase 4 - Manual upload to Chrome Web Store.
 

--- a/README.md
+++ b/README.md
@@ -91,45 +91,6 @@ The extension requires these permissions:
 
 Want to contribute? See [CONTRIBUTING.md](CONTRIBUTING.md) for developer setup and guidelines.
 
-## Release workflow
-
-We manage releases with [`just`](https://just.systems/man/en/) recipes and shell scripts.
-
-1. **Prepare the release branch**
-
-   ```bash
-   just release-bump 0.2.4
-   # or just release-bump patch|minor|major to auto-increment from the current version
-   ```
-
-   - Ensures you are on `main` with a clean working tree
-   - Runs `npm run typecheck` from `main`
-   - Creates or switches to `release/v0.2.4` (or the computed version)
-   - Updates version metadata and regenerates `CHANGELOG.md`
-     with the latest commit titles
-
-2. **Commit and open the draft PR**
-
-   ```bash
-   just release-submit
-   ```
-
-   - Commits the staged release files
-   - Pushes the release branch
-   - Opens a draft PR populated with the changelog entry
-
-3. **Publish after the PR merges**
-
-   ```bash
-   just release-publish 0.2.4
-   ```
-
-   - Verifies `main` matches the merged release
-   - Builds the extension, creates `mountaineers-assistant-0.2.4.zip`, and tags the release
-   - Creates the GitHub release with the ZIP attached
-
-These recipes require the GitHub CLI (`gh`), `npm`, `jq`, and `zip`. Install `just` locally to run them.
-
 ## Changelog
 
 See [CHANGELOG.md](CHANGELOG.md) for a list of changes in each release.


### PR DESCRIPTION
## Summary

- Removed release workflow section from README.md (it belonged in CONTRIBUTING.md)
- Updated CONTRIBUTING.md release process to use current `just` commands
- Replaced outdated `npm run release:*` commands with `just release-*`
- Added prerequisites section for installing just and dependencies

## Changes

**README.md:**
- Removed the "Release workflow" section (lines 94-131)
- This section was developer documentation that didn't belong in the user-facing README

**CONTRIBUTING.md:**
- Replaced outdated Phase 1-4 release process using `npm run release:*` commands
- Updated with current workflow using `just release-bump`, `just release-submit`, and `just release-publish`
- Added prerequisites section showing how to install `just` and dependencies
- Maintained all four phases (bump, submit, auto-publish, manual Chrome Web Store upload)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated release process documentation with streamlined workflow and command patterns for contributors.
  * Removed release workflow section from general documentation to consolidate contributor guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->