### PR TITLE
chore: add Ko-fi funding link

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,0 +1,1 @@
+ko_fi: Q3N622FHZM


### PR DESCRIPTION
Adds .github/FUNDING.yml with the Ko-fi tip-jar link so the repo shows a Sponsor button.

🤖 Generated with [Claude Code](https://claude.com/claude-code)