### PR TITLE
chore: pin actions to SHAs, standardize README

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,6 +5,8 @@ updates:
     schedule:
       interval: weekly
       day: monday
+    cooldown:
+      default-days: 7
     commit-message:
       prefix: "ci(deps)"
     groups:
@@ -17,6 +19,8 @@ updates:
     schedule:
       interval: weekly
       day: monday
+    cooldown:
+      default-days: 7
     open-pull-requests-limit: 5
     commit-message:
       prefix: "chore(deps)"
@@ -33,6 +37,8 @@ updates:
     schedule:
       interval: weekly
       day: monday
+    cooldown:
+      default-days: 7
     commit-message:
       prefix: "chore(deps)"
     groups:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,8 +15,8 @@ jobs:
     name: Lint
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v7
-      - uses: oven-sh/setup-bun@v2
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+      - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
         with:
           bun-version: latest
       - run: bun install --frozen-lockfile
@@ -26,8 +26,8 @@ jobs:
     name: Typecheck
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v7
-      - uses: oven-sh/setup-bun@v2
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+      - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
         with:
           bun-version: latest
       - run: bun install --frozen-lockfile
@@ -37,15 +37,15 @@ jobs:
     name: Test
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v7
-      - uses: oven-sh/setup-bun@v2
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+      - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
         with:
           bun-version: latest
       - run: bun install --frozen-lockfile
       - run: npx c8 --reporter=text --reporter=lcov --check-coverage --lines=70 --functions=70 --branches=70 --statements=70 bun x tsx --test tests/unit/*.test.ts
       - name: Upload coverage
         if: always()
-        uses: codecov/codecov-action@v7
+        uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7
         with:
           files: ./coverage/lcov.info
           fail_ci_if_error: true
@@ -54,7 +54,7 @@ jobs:
     name: SAST
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
       - name: Install Semgrep
         run: pip install semgrep==1.151.0
       - name: Run Semgrep
@@ -68,7 +68,7 @@ jobs:
     name: Complexity
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
       - name: Install lizard
         run: pip install lizard==1.17.13
       - name: Check complexity
@@ -79,8 +79,8 @@ jobs:
     name: Build
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v7
-      - uses: oven-sh/setup-bun@v2
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+      - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
         with:
           bun-version: latest
       - run: bun install --frozen-lockfile

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -26,13 +26,13 @@ jobs:
       actions: read # Required for Claude to read CI results on PRs
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v7
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
         with:
           fetch-depth: 1
 
       - name: Run Claude Code
         id: claude
-        uses: anthropics/claude-code-action@v1
+        uses: anthropics/claude-code-action@6c0083bb7289c31716797a039b6367b3079cc46e # v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
 

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -13,7 +13,7 @@ jobs:
     steps:
       - name: Fetch Dependabot metadata
         id: metadata
-        uses: dependabot/fetch-metadata@v3
+        uses: dependabot/fetch-metadata@25dd0e34f4fe68f24cc83900b1fe3fe149efef98 # v3
         with:
           github-token: "${{ secrets.GITHUB_TOKEN }}"
 

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -11,10 +11,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v7
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
 
       - name: Dependency Review
-        uses: actions/dependency-review-action@v5
+        uses: actions/dependency-review-action@a1d282b36b6f3519aa1f3fc636f609c47dddb294 # v5
         with:
           fail-on-severity: high
           comment-summary-in-pr: on-failure

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -17,7 +17,7 @@ jobs:
       tag_name: ${{ steps.release.outputs.tag_name }}
       version: ${{ steps.release.outputs.major }}.${{ steps.release.outputs.minor }}.${{ steps.release.outputs.patch }}
     steps:
-      - uses: googleapis/release-please-action@v5
+      - uses: googleapis/release-please-action@45996ed1f6d02564a971a2fa1b5860e934307cf7 # v5
         id: release
         with:
           config-file: release-please-config.json
@@ -31,10 +31,10 @@ jobs:
       contents: write
     steps:
       - name: Checkout code
-        uses: actions/checkout@v7
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
 
       - name: Setup Bun
-        uses: oven-sh/setup-bun@v2
+        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
         with:
           bun-version: latest
 

--- a/README.md
+++ b/README.md
@@ -1,10 +1,12 @@
 # Mountaineers Assistant
-[![CI](https://github.com/dreamiurg/mountaineers-assistant/actions/workflows/ci.yml/badge.svg)](https://github.com/dreamiurg/mountaineers-assistant/actions/workflows/ci.yml)
-[![codecov](https://codecov.io/gh/dreamiurg/mountaineers-assistant/graph/badge.svg)](https://codecov.io/gh/dreamiurg/mountaineers-assistant)
 
 **Ever wonder who you've climbed with the most? Or how many activities you've done this year?**
 
 Mountaineers.org doesn't make it easy to explore your own activity history. This extension fixes that.
+
+> **Other projects you might like:** [PNW Climb Planner](https://dreamiurg.net/pnw-climb-planner.html) · [mountaineers-mcp](https://github.com/dreamiurg/mountaineers-mcp) · [peakbagger-cli](https://github.com/dreamiurg/peakbagger-cli) · [claude-mountaineering-skills](https://github.com/dreamiurg/claude-mountaineering-skills)
+
+<a href='https://ko-fi.com/Q3N622FHZM' target='_blank'><img height='36' style='border:0px;height:36px;' src='https://storage.ko-fi.com/cdn/kofi5.png?v=6' border='0' alt='Buy Me a Coffee at ko-fi.com' /></a>
 
 ![Insights dashboard](tests/chrome-extension/insights-dashboard-visual.spec.ts-snapshots/insights-default-chromium-extension-darwin.png)
 
@@ -83,18 +85,16 @@ bun run ci               # Full local CI (check + test + complexity + build)
 
 Your data **never leaves your browser**. No servers, no analytics, no third parties. [Full privacy policy →](PRIVACY.md)
 
----
-
-## Other Mountaineering & Outdoors Tools
-
-I climb, scramble, and hike a lot, and I keep building tools around it. If this one's useful to you, the others might be too:
-
-- **[mountaineers-mcp](https://github.com/dreamiurg/mountaineers-mcp)** -- MCP server that lets AI assistants search and browse mountaineers.org. Activities, courses, trip reports, your account data. Works with Claude Desktop, Claude Code, and Codex CLI.
-- **[peakbagger-cli](https://github.com/dreamiurg/peakbagger-cli)** -- Command-line access to PeakBagger.com. Search peaks, check elevation and prominence, browse ascent stats. Outputs JSON for piping into other tools.
-- **[claude-mountaineering-skills](https://github.com/dreamiurg/claude-mountaineering-skills)** -- Claude Code plugin that generates route beta reports by pulling conditions, forecasts, and trip reports from multiple mountaineering sites.
-
----
-
-Built in Seattle by a [fellow Mountaineer](https://www.mountaineers.org/members/dmytro-gayvoronskyy).
-
 Questions? [Open an issue](https://github.com/dreamiurg/mountaineers-assistant/issues) · Want to help? [Contributing guide](CONTRIBUTING.md)
+
+---
+
+## More from @dreamiurg
+
+- 🏔️ **[PNW Climb Planner](https://dreamiurg.net/pnw-climb-planner.html)** — pick a Washington peak, see the odds of a climbable day from 20 years of weather data, and line up backups ([the story behind it](https://dreamiurg.net/2026/07/01/picking-backup-climbs.html))
+- **[mountaineers-mcp](https://github.com/dreamiurg/mountaineers-mcp)** — mountaineers.org for AI assistants: activities, courses, routes, trip reports
+- **[peakbagger-cli](https://github.com/dreamiurg/peakbagger-cli)** — search and analyze PeakBagger.com peak data in your terminal
+- **[claude-mountaineering-skills](https://github.com/dreamiurg/claude-mountaineering-skills)** — automated route research: weather, hazards, and trip reports in one report
+- more at [dreamiurg.net/projects](https://dreamiurg.net/projects/)
+
+Made by [@dreamiurg](https://dreamiurg.net) in Seattle. If this project saved you time, you can [buy me a coffee](https://ko-fi.com/Q3N622FHZM) — appreciated, never expected.


### PR DESCRIPTION
## Summary

- Pin all GitHub Actions in `.github/workflows/` to full commit SHAs (with tag comments) — this fixes the failing SAST check on main, which flags unpinned action refs via `semgrep --config auto`.
- Standardize README: drop CI/codecov badges, add cross-project links and Ko-fi button under the intro, replace the old "Other Mountaineering & Outdoors Tools" section with the standardized "More from @dreamiurg" footer.

No functional changes to the extension.

🤖 Generated with [Claude Code](https://claude.com/claude-code)